### PR TITLE
Update test-static-stdlib for swift-foundation

### DIFF
--- a/test-static-stdlib/main.swift
+++ b/test-static-stdlib/main.swift
@@ -3,4 +3,4 @@ import Foundation
 
 let u = URL(fileURLWithPath: "file:///foo")
 
-print("foo bar baz: \(u)")
+print("foo bar baz: \(u.relativePath)")


### PR DESCRIPTION
With swift-foundation landing in the toolchain, the behavior of `URL.description` has changed. This test relies on this behavior and it fails with the new toolchain builds. Instead, this updates the tests to call `URL.relativePath` directly (which behaves as the previous `URL.description` did but is also consistent in behavior with swift-foundation. This makes the test more reliable and passes with both the old and new Foundation