### PR TITLE
[6.0] Update test-static-stdlib for swift-foundation

### DIFF
--- a/test-static-stdlib/main.swift
+++ b/test-static-stdlib/main.swift
@@ -3,4 +3,4 @@ import Foundation
 
 let u = URL(fileURLWithPath: "file:///foo")
 
-print("foo bar baz: \(u)")
+print("foo bar baz: \(u.relativePath)")


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/swift-integration-tests/pull/139

Explanation: Updates the test so that it will pass with the new swift-foundation recore in the toolchain
Scope: Affects a single test run during package testing
Original PR: https://github.com/swiftlang/swift-integration-tests/pull/139
Risk: Minimal - this is a minor test-only change that is backwards and forwards compatible with the old SCL-F and the new SCL-F recored on swift-foundation
Testing: Testing done via local toolchain build and execution of test
Reviewer: @etcwilde @MaxDesiatov 