### PR TITLE
Fix file URL in test-static-stdlib

### DIFF
--- a/test-static-stdlib/main.swift
+++ b/test-static-stdlib/main.swift
@@ -1,6 +1,6 @@
 
 import Foundation
 
-let u = URL(fileURLWithPath: "file:///foo")
+let u = URL(fileURLWithPath: "/foo")
 
 print("foo bar baz: \(u.relativePath)")

--- a/test-static-stdlib/test-static-stdlib.test
+++ b/test-static-stdlib/test-static-stdlib.test
@@ -4,4 +4,4 @@ RUN: mkdir -p %t
 RUN: %{swiftc} -static-stdlib %S/main.swift -o %t/main
 RUN: %t/main | %{FileCheck} %s
 
-CHECK: foo bar baz: file:/foo
+CHECK: foo bar baz: /foo


### PR DESCRIPTION
`URL(fileURLWithPath:)` takes a URL path that doesn't include the `file:` scheme, so `URL(fileURLWithPath: "file:///foo")` treats the entire `file:///foo` as a relative path (since it doesn't start with a `/`).

In https://github.com/apple/swift-foundation/pull/792, we updated relative path parsing to no longer compress slashes (matching the behavior of all common RFC 3986 and WHATWG parsers), so the output of `u.relativePath` changed from `file:/foo` to `file:///foo`, causing this test to fail.

This PR updates the test to use the file URL API as expected and updates the check in accordance, e.g.
```
let u = URL(fileURLWithPath: "/foo")
print("foo bar baz: \(u.relativePath)")
// ...
CHECK: foo bar baz: /foo
```
and should fix the Linux builds.