### PR TITLE
[6.0] Fix file URL in test-static-stdlib

### DIFF
--- a/test-static-stdlib/main.swift
+++ b/test-static-stdlib/main.swift
@@ -1,6 +1,6 @@
 
 import Foundation
 
-let u = URL(fileURLWithPath: "file:///foo")
+let u = URL(fileURLWithPath: "/foo")
 
 print("foo bar baz: \(u.relativePath)")

--- a/test-static-stdlib/test-static-stdlib.test
+++ b/test-static-stdlib/test-static-stdlib.test
@@ -4,4 +4,4 @@ RUN: mkdir -p %t
 RUN: %{swiftc} -static-stdlib %S/main.swift -o %t/main
 RUN: %t/main | %{FileCheck} %s
 
-CHECK: foo bar baz: file:/foo
+CHECK: foo bar baz: /foo


### PR DESCRIPTION
Cherry-pick of #143 for release/6.0

Explanation: Updates the test so that it will pass with new swift-foundation `URL(fileURLWithPath:)` behavior that no longer removes consecutive slashes. This matches the behavior of all common RFC 3986 and WHATWG parsers, but caused this test to fail on `main` and `release/6.0`.
Scope: Affects a single test run during package testing
Original PR: https://github.com/swiftlang/swift-integration-tests/pull/143
Risk: Minimal - minor test-only change that is backwards and forwards compatible with the old swift-corelibs-foundation and new swift-foundation URL behavior
Testing: Swift smoke tests including branch
Reviewer: @etcwilde