### PR TITLE
Update checked linux rpath to disallow `/opt/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ swift-project.
 
 Run the tests using:
 
-    sh ./litTest -sv --param package-path=/path/to/downloadable-package .
+    sh ./litTest -sv --param package-path=/path/to/downloadable-package --param llvm-bin-dir=/usr/bin .
 
-where the path is the unarchived package root path.
+where the first path is the unarchived package root path and the second has LLVM
+utilities like `FileCheck`.
 
 Tests
 -----

--- a/test-snapshot-binaries/test-rpath-linux.py
+++ b/test-snapshot-binaries/test-rpath-linux.py
@@ -42,6 +42,8 @@
 #
 # RUN: find %{package_path} -name "lib*\.so" | xargs %{readelf} -d | %{FileCheck} --check-prefix CHECK-LIB %s
 # CHECK-LIB-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/home/
+# CHECK-LIB-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/opt/
 #
 # RUN: find %{package_path}/usr/bin -type f | grep -Ev "\.py|\.txt|\.sh|\.cfg" | xargs %{readelf} -d | %{FileCheck} --check-prefix CHECK-BIN %s
 # CHECK-BIN-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/home/
+# CHECK-BIN-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/opt/


### PR DESCRIPTION
which is where the prebuilt toolchain on the CI is now installed. Also, update the README with required `llvm-bin-dir` flag.

@al45tair, maybe you can review?

This cannot be merged until the fix for this issue, swiftlang/swift#75585, is merged first.