### PR TITLE
[6.0] Add basic integration tests for Swift Testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,19 @@ Tests
 
 Here is a partial list of tests in the repository:
 
-| Test Name                | Functionality                                                    |
-|--------------------------|------------------------------------------------------------------|
-| basic                    | Check output of `swift --version`                                |
-| example-package-dealer   | Build the example package-dealer package                         |
-| repl                     | Various REPL sanity checks, notably importing Darwin and Glibc   |
-| swift-build-self-host    | Use swift build to build itself                                  |
-| swift-compiler           | Compile a basic swift file                                       |
-| test-c-library-swiftpm   | Build a package that links a 3rd party library                   |
-| test-foundation-package  | Build a package that imports Foundation                          |
-| test-import-glibc        | Compile a source file importing and using Glibc                  |
-| test-multi-compile       | Compile multiple source files into an executable                 |
-| test-multi-compile-glibc | Compile multiple source files importing Glibc into an executable |
-| test-static-lib          | Compile multiple source files into a static library              |
-| test-xctest-package      | Build a package that imports XCTest                              |
+| Test Name                  | Functionality                                                    |
+|----------------------------|------------------------------------------------------------------|
+| basic                      | Check output of `swift --version`                                |
+| example-package-dealer     | Build the example package-dealer package                         |
+| repl                       | Various REPL sanity checks, notably importing Darwin and Glibc   |
+| swift-build-self-host      | Use swift build to build itself                                  |
+| swift-compiler             | Compile a basic swift file                                       |
+| test-c-library-swiftpm     | Build a package that links a 3rd party library                   |
+| test-foundation-package    | Build a package that imports Foundation                          |
+| test-import-glibc          | Compile a source file importing and using Glibc                  |
+| test-multi-compile         | Compile multiple source files into an executable                 |
+| test-multi-compile-glibc   | Compile multiple source files importing Glibc into an executable |
+| test-static-lib            | Compile multiple source files into a static library              |
+| test-xctest-package        | Build a package that imports XCTest                              |
+| test-swift-testing-package | Build a package that imports Swift Testing                       |
 

--- a/swift-package-init-lib.md
+++ b/swift-package-init-lib.md
@@ -6,9 +6,10 @@
 ```
 RUN: rm -rf %t.dir
 RUN: mkdir -p %t.dir/Project
-RUN: %{swift-package} --package-path %t.dir/Project init --type library
+RUN: %{swift-package} --package-path %t.dir/Project init --type library --enable-xctest --enable-swift-testing
 RUN: %{swift-build} --package-path %t.dir/Project 2>&1 | tee %t.build-log
-RUN: %{swift-test} --package-path %t.dir/Project 2>&1 | tee %t.test-log
+RUN: %{swift-test} --package-path %t.dir/Project --enable-xctest --disable-swift-testing 2>&1 | tee %t.xctest-log
+RUN: %{swift-test} --package-path %t.dir/Project --disable-xctest --enable-swift-testing 2>&1 | tee %t.swift-testing-log
 ```
 
 ## Check the build log.
@@ -21,23 +22,35 @@ RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
 CHECK-BUILD-LOG: Compiling {{.*}}Project{{.*}}
 ```
 
-## Check the test log.
+## Check the XCTest log.
 
 ```
-RUN: %{FileCheck} --check-prefix CHECK-TEST-LOG --input-file %t.test-log %s
+RUN: %{FileCheck} --check-prefix CHECK-XCTEST-LOG --input-file %t.xctest-log %s
 ```
 
 ```
-CHECK-TEST-LOG: Compiling {{.*}}ProjectTests{{.*}}
-CHECK-TEST-LOG: Test Suite 'All tests' passed
-CHECK-TEST-LOG-NEXT: Executed 1 test
+CHECK-XCTEST-LOG: Compiling {{.*}}ProjectTests{{.*}}
+CHECK-XCTEST-LOG: Test Suite 'All tests' passed
+CHECK-XCTEST-LOG-NEXT: Executed 1 test
+```
+
+## Check the Swift Testing log.
+
+```
+RUN: %{FileCheck} --check-prefix CHECK-SWIFT-TESTING-LOG --input-file %t.swift-testing-log %s
+```
+
+```
+CHECK-SWIFT-TESTING-LOG: Test run started.
+CHECK-SWIFT-TESTING-LOG: Test run with 1 test passed after {{.*}} seconds.
 ```
 
 ## Check there were no compile errors or warnings.
 
 ```
 RUN: %{FileCheck} --check-prefix CHECK-NO-WARNINGS-OR-ERRORS --input-file %t.build-log %s
-RUN: %{FileCheck} --check-prefix CHECK-NO-WARNINGS-OR-ERRORS --input-file %t.test-log %s
+RUN: %{FileCheck} --check-prefix CHECK-NO-WARNINGS-OR-ERRORS --input-file %t.xctest-log %s
+RUN: %{FileCheck} --check-prefix CHECK-NO-WARNINGS-OR-ERRORS --input-file %t.swift-testing-log %s
 ```
 
 ```

--- a/test-swift-testing-package/Tests.swift
+++ b/test-swift-testing-package/Tests.swift
@@ -1,0 +1,5 @@
+import Testing
+
+@Test func test_example() {
+  print("HI")
+}

--- a/test-swift-testing-package/test-swift-testing-package.txt
+++ b/test-swift-testing-package/test-swift-testing-package.txt
@@ -1,0 +1,34 @@
+// swift-tools-version:6.0
+// Trivial test for importing Swift Testing.
+//
+// REQUIRES: platform=Linux
+//
+// Make a sandbox dir.
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir/tool
+// RUN: cp %s %t.dir/tool/Package.swift
+// RUN: cp %S/Tests.swift %t.dir/tool/Tests.swift
+// RUN: %{swift-build} --build-tests --package-path %t.dir/tool -v 2>&1 | tee %t.build-log
+//
+// Check the build log.
+//
+// RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
+//
+// CHECK-BUILD-LOG: swiftc{{.*}} -module-name tool
+//
+// Verify that the tool exists and works.
+//
+// RUN: test -x %t.dir/tool/.build/debug/toolPackageTests.xctest
+// RUN: %t.dir/tool/.build/debug/toolPackageTests.xctest --testing-library swift-testing > %t.out
+// RUN: %{FileCheck} --check-prefix CHECK-TOOL-OUTPUT --input-file %t.out %s
+//
+// CHECK-TOOL-OUTPUT: HI
+
+import PackageDescription
+
+let package = Package(
+   name: "tool",
+   targets: [
+       .testTarget(name: "tool", path: "./"),
+   ]
+)


### PR DESCRIPTION
**Explanation:** Updates integration tests around XCTest to support Swift Testing
**Scope:** 6.0 branch
**Issue:** N/A
**Original PR:** https://github.com/swiftlang/swift-integration-tests/pull/146
**Risk:** Low
**Testing:** Tested in a side toolchain build here: https://github.com/swiftlang/swift/pull/71188
**Reviewer:** @bnbarham