### PR TITLE
Add package tests for FoundationEssentials, FoundationInternationalization, and FoundationMacros

### DIFF
--- a/test-foundation-package/test-foundation-essentials.swift
+++ b/test-foundation-package/test-foundation-essentials.swift
@@ -1,0 +1,4 @@
+import FoundationEssentials
+
+let data = Data([1, 2, 3])
+print(data)

--- a/test-foundation-package/test-foundation-essentials.txt
+++ b/test-foundation-package/test-foundation-essentials.txt
@@ -1,0 +1,8 @@
+REQUIRES: platform=Linux
+RUN: rm -rf %t
+RUN: mkdir -p %t
+RUN: %{swiftc}  -o %t/test-foundation-essentials %S/test-foundation-essentials.swift
+RUN: %t/test-foundation-essentials | %{FileCheck} %s
+CHECK: bytes
+LLD-NOT: libFoundation.so
+LLD-NOT: libFoundationInternationalization.so

--- a/test-foundation-package/test-foundation-internationalization.swift
+++ b/test-foundation-package/test-foundation-internationalization.swift
@@ -1,0 +1,4 @@
+import FoundationInternationalization
+
+let locale = Locale(identifier: "en_US")
+print(locale)

--- a/test-foundation-package/test-foundation-internationalization.swift
+++ b/test-foundation-package/test-foundation-internationalization.swift
@@ -1,4 +1,4 @@
 import FoundationInternationalization
 
-let locale = Locale(identifier: "en_US")
-print(locale)
+let style = IntegerFormatStyle<Int>()
+print(style)

--- a/test-foundation-package/test-foundation-internationalization.txt
+++ b/test-foundation-package/test-foundation-internationalization.txt
@@ -3,5 +3,5 @@ RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %{swiftc}  -o %t/test-foundation-internationalization %S/test-foundation-internationalization.swift
 RUN: %t/test-foundation-internationalization | %{FileCheck} %s
-CHECK: en_US
+CHECK: IntegerFormatStyle
 LLD-NOT: libFoundation.so

--- a/test-foundation-package/test-foundation-internationalization.txt
+++ b/test-foundation-package/test-foundation-internationalization.txt
@@ -1,0 +1,7 @@
+REQUIRES: platform=Linux
+RUN: rm -rf %t
+RUN: mkdir -p %t
+RUN: %{swiftc}  -o %t/test-foundation-internationalization %S/test-foundation-internationalization.swift
+RUN: %t/test-foundation-internationalization | %{FileCheck} %s
+CHECK: en_US
+LLD-NOT: libFoundation.so

--- a/test-foundation-package/test-foundation-macros.swift
+++ b/test-foundation-package/test-foundation-macros.swift
@@ -1,0 +1,10 @@
+import FoundationEssentials
+
+#if canImport(FoundationMacros)
+#error("Should not be able to import the FoundationMacros module directly")
+#endif
+
+let predicate = #Predicate<Int> {
+	$0 > 2
+}
+print(predicate)

--- a/test-foundation-package/test-foundation-macros.txt
+++ b/test-foundation-package/test-foundation-macros.txt
@@ -1,0 +1,8 @@
+REQUIRES: platform=Linux
+RUN: rm -rf %t
+RUN: mkdir -p %t
+RUN: %{swiftc}  -o %t/test-foundation-macros %S/test-foundation-macros.swift
+RUN: %t/test-foundation-macros | %{FileCheck} %s
+CHECK: Predicate
+LLD-NOT: libFoundationMacros.so
+LLD-NOT: libFoundation.so


### PR DESCRIPTION
The package integration tests already include very small, fundamental tests to ensure that the Foundation libraries in the toolchain can be loaded. Now that Foundation's tests are built and run with SwiftPM, these package integration tests are critical to ensure that the binaries installed into the toolchain are functional (have correct rpaths, are installed to the proper locations, link the appropriate libraries, etc.) since the unit tests will rely on separately built, testable binaries that are not installed. This expands the set of tests within the Foundation package tests to also exercise imports of FoundationEssentials and FoundationInternationalization, as well as ensure that FoundationMacros can be loaded by the compiler. The last piece is the main driver for adding this, since nothing in the toolchain today uses FoundationMacros, so this is important to avoid shipping a broken macro module.