### PR TITLE
[test-sourcekit-lsp] Use `communicate` to wait for subprocess to exit

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -110,7 +110,12 @@ class LspConnection:
         """
         Wait for the LSP server to terminate.
         """
-        return self.process.wait(timeout)
+        stdout, stderr = self.process.communicate(timeout=timeout)
+        print("stdout before exit")
+        print(stdout)
+        print("stderr before exit")
+        print(stderr)
+        return self.process.returncode
 
 
 def main():
@@ -227,7 +232,7 @@ def main():
     connection.send_request("shutdown", {})
     connection.send_notification("exit", {})
 
-    return_code = connection.wait_for_exit(timeout=1)
+    return_code = connection.wait_for_exit(timeout=5)
     if return_code == 0:
         print("OK")
     else:


### PR DESCRIPTION
https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait says that `wait` can deadlock if the process use pipes (which we do) and if it generates too much output.

Might fix rdar://140425949 but I’m entirely certain because that radar looks like a crash in LLVM, which I don’t fully understand.