### PR TITLE
[6.1][test-sourcekit-lsp] Use `communicate` to wait for subprocess to exit

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -108,7 +108,12 @@ class LspConnection:
         """
         Wait for the LSP server to terminate.
         """
-        return self.process.wait(timeout)
+        stdout, stderr = self.process.communicate(timeout=timeout)
+        print("stdout before exit")
+        print(stdout)
+        print("stderr before exit")
+        print(stderr)
+        return self.process.returncode
 
 
 def main():
@@ -225,7 +230,7 @@ def main():
     connection.send_request("shutdown", {})
     connection.send_notification("exit", {})
 
-    return_code = connection.wait_for_exit(timeout=1)
+    return_code = connection.wait_for_exit(timeout=5)
     if return_code == 0:
         print("OK")
     else:


### PR DESCRIPTION
- Explanation: Fixes a deadlock if the process generates too much output.

- Main Branch PRs: https://github.com/swiftlang/swift-integration-tests/pull/150

- Risk: Very low, has been on main for a while now

- Resolves: rdar://144733940

- Reviewed By: @hamishknight 