### PR TITLE
test-dispatch-static-stdlib: drop DispatchStubs

### DIFF
--- a/test-static-stdlib/test-dispatch-static-stdlib.test
+++ b/test-static-stdlib/test-dispatch-static-stdlib.test
@@ -1,7 +1,7 @@
 REQUIRES: platform=Linux
 RUN: rm -rf %t
 RUN: mkdir -p %t
-RUN: %{swiftc} -static-stdlib %S/dispatch_test.swift -ldispatch -lswiftDispatch -lDispatchStubs -o %t/dispatch_test
+RUN: %{swiftc} -static-stdlib %S/dispatch_test.swift -ldispatch -lswiftDispatch -o %t/dispatch_test
 RUN: %t/dispatch_test | %{FileCheck} %s
 
 CHECK: OK


### PR DESCRIPTION
This was used originally for the autorelease elision stub but is no longer needed. The stubs now simply service the ObjC runtime support, which is not enabled on Linux. This cleans up the invocation to allow simplifying the libdispatch build.