### PR TITLE
Disable test-sourcekit-lsp.py

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -1,6 +1,7 @@
 # Canary test for sourcekit-lsp, covering interaction with swiftpm and toolchain
 # language services.
 
+# REQUIRES: rdar147100271
 # REQUIRES: have-sourcekit-lsp
 
 # Make a sandbox dir.


### PR DESCRIPTION
Test failure tracked by rdar://147100271.