### PR TITLE
Update swift-package-init-lib to match new Testing output for suites

### DIFF
--- a/swift-package-init-lib.md
+++ b/swift-package-init-lib.md
@@ -42,7 +42,7 @@ RUN: %{FileCheck} --check-prefix CHECK-SWIFT-TESTING-LOG --input-file %t.swift-t
 
 ```
 CHECK-SWIFT-TESTING-LOG: Test run started.
-CHECK-SWIFT-TESTING-LOG: Test run with 1 test passed after {{.*}} seconds.
+CHECK-SWIFT-TESTING-LOG: Test run with 1 test in 0 suites passed after {{.*}} seconds.
 ```
 
 ## Check there were no compile errors or warnings.


### PR DESCRIPTION
@stmontgomery, looks like swiftlang/swift-testing#1116 [broke this test on the linux CI](https://ci.swift.org/job/oss-swift-package-ubuntu-20_04/4150/console), please review.