### PR TITLE
Update swift-package-init-lib to match new Testing output for suites from swiftlang/swift-testing#1116 (#159)

### DIFF
--- a/swift-package-init-lib.md
+++ b/swift-package-init-lib.md
@@ -42,7 +42,7 @@ RUN: %{FileCheck} --check-prefix CHECK-SWIFT-TESTING-LOG --input-file %t.swift-t
 
 ```
 CHECK-SWIFT-TESTING-LOG: Test run started.
-CHECK-SWIFT-TESTING-LOG: Test run with 1 test passed after {{.*}} seconds.
+CHECK-SWIFT-TESTING-LOG: Test run with 1 test in 0 suites passed after {{.*}} seconds.
 ```
 
 ## Check there were no compile errors or warnings.


### PR DESCRIPTION
__Explanation:__ A simple libTesting output change has to be updated here too, as the 6.2 CI just broke because of this same issue that I fixed in trunk last weekend, after the upstream commit was just auto-merged to 6.2, swiftlang/swift-testing@ae7131366.

__Scope:__ Minor Testing output update

__Issue:__ swiftlang/swift-testing#1021

__Original PR:__ #159

__Risk:__ None

__Testing:__ Got all trunk CI running again

__Reviewer:__ @stmontgomery 

@jakepetroules, this will fix the 6.2 CI.